### PR TITLE
Feat: allow operators to set custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ OMS_POST_TIMEOUT          : HTTP post timeout for sending events to OMS Log Anal
 OMS_BATCH_TIME            : Interval for posting a batch to OMS Log Analytics
 OMS_MAX_MSG_NUM_PER_BATCH : The max number of messages in a batch to OMS Log Analytics
 API_ADDR                  : The API address of the CF environment. If set empty or absent, nozzle will use API address for current CF environment
+AZURE_RESOURCE_ID         : Resource Id to include as an HTTP header when posting events
 DOPPLER_ADDR              : Loggregator's traffic controller URL. If set empty or absent, nozzle will generate it from API address
 FIREHOSE_USER             : CF user who has admin and firehose access
 FIREHOSE_USER_PASSWORD    : Password of the CF user

--- a/client/oms_client.go
+++ b/client/oms_client.go
@@ -23,12 +23,12 @@ type Client interface {
 
 // Client posts messages to OMS
 type client struct {
-	customerID       string
-	sharedKey        string
-	url              string
-	httpPostTimeout  time.Duration
-	logger           lager.Logger
-	omsCustomHeaders map[string]string
+	customerID      string
+	sharedKey       string
+	url             string
+	httpPostTimeout time.Duration
+	logger          lager.Logger
+	azureResourceId string
 }
 
 const (
@@ -42,14 +42,14 @@ func init() {
 }
 
 // New instance of the Client
-func NewOmsClient(customerID string, sharedKey string, postTimeout time.Duration, omsCustomHeaders map[string]string, logger lager.Logger) Client {
+func NewOmsClient(customerID string, sharedKey string, postTimeout time.Duration, azureResourceId string, logger lager.Logger) Client {
 	return &client{
-		customerID:       customerID,
-		sharedKey:        sharedKey,
-		url:              "https://" + customerID + ".ods.opinsights.azure.com" + resource + "?api-version=2016-04-01",
-		httpPostTimeout:  postTimeout,
-		logger:           logger,
-		omsCustomHeaders: omsCustomHeaders,
+		customerID:      customerID,
+		sharedKey:       sharedKey,
+		url:             "https://" + customerID + ".ods.opinsights.azure.com" + resource + "?api-version=2016-04-01",
+		httpPostTimeout: postTimeout,
+		logger:          logger,
+		azureResourceId: azureResourceId,
 	}
 }
 
@@ -77,10 +77,10 @@ func (c *client) PostData(msg *[]byte, logType string) error {
 	//TODO: headers should be case insentitive
 	//req.Header.Set("x-ms-date", rfc1123date)
 	req.Header["x-ms-date"] = []string{rfc1123date}
-	req.Header.Set("Content-Type", "application/json")
-	for key, value := range c.omsCustomHeaders {
-		req.Header[key] = []string{value}
+	if c.azureResourceId != "" {
+		req.Header["x-ms-AzureResourceId"] = []string{c.azureResourceId}
 	}
+	req.Header.Set("Content-Type", "application/json")
 
 	client := http.Client{
 		Timeout: c.httpPostTimeout,

--- a/client/oms_client.go
+++ b/client/oms_client.go
@@ -23,11 +23,12 @@ type Client interface {
 
 // Client posts messages to OMS
 type client struct {
-	customerID      string
-	sharedKey       string
-	url             string
-	httpPostTimeout time.Duration
-	logger          lager.Logger
+	customerID       string
+	sharedKey        string
+	url              string
+	httpPostTimeout  time.Duration
+	logger           lager.Logger
+	omsCustomHeaders map[string]string
 }
 
 const (
@@ -41,13 +42,14 @@ func init() {
 }
 
 // New instance of the Client
-func NewOmsClient(customerID string, sharedKey string, postTimeout time.Duration, logger lager.Logger) Client {
+func NewOmsClient(customerID string, sharedKey string, postTimeout time.Duration, omsCustomHeaders map[string]string, logger lager.Logger) Client {
 	return &client{
-		customerID:      customerID,
-		sharedKey:       sharedKey,
-		url:             "https://" + customerID + ".ods.opinsights.azure.com" + resource + "?api-version=2016-04-01",
-		httpPostTimeout: postTimeout,
-		logger:          logger,
+		customerID:       customerID,
+		sharedKey:        sharedKey,
+		url:              "https://" + customerID + ".ods.opinsights.azure.com" + resource + "?api-version=2016-04-01",
+		httpPostTimeout:  postTimeout,
+		logger:           logger,
+		omsCustomHeaders: omsCustomHeaders,
 	}
 }
 
@@ -76,6 +78,9 @@ func (c *client) PostData(msg *[]byte, logType string) error {
 	//req.Header.Set("x-ms-date", rfc1123date)
 	req.Header["x-ms-date"] = []string{rfc1123date}
 	req.Header.Set("Content-Type", "application/json")
+	for key, value := range c.omsCustomHeaders {
+		req.Header[key] = []string{value}
+	}
 
 	client := http.Client{
 		Timeout: c.httpPostTimeout,

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ var (
 	omsWorkspace         = kingpin.Flag("oms-workspace", "OMS workspace ID").OverrideDefaultFromEnvar("OMS_WORKSPACE").Required().String()
 	omsKey               = kingpin.Flag("oms-key", "OMS workspace key").OverrideDefaultFromEnvar("OMS_KEY").Required().String()
 	omsPostTimeout       = kingpin.Flag("oms-post-timeout", "HTTP timeout for posting events to OMS Log Analytics").Default("5s").OverrideDefaultFromEnvar("OMS_POST_TIMEOUT").Duration()
-	azureResourceId      = kingpin.Flag("azure-resource-id", "Azure Resource Id to set in HTTP header when posting events to Azure Monitor").OverrideDefaultFromEnvar("AZURE_RESOURCE_ID").String()
+	azureResourceId      = kingpin.Flag("azure-resource-id", "Resource Id to include as an HTTP header when posting events").OverrideDefaultFromEnvar("AZURE_RESOURCE_ID").String()
 	omsBatchTime         = kingpin.Flag("oms-batch-time", "Interval to post an OMS batch").Default("5s").OverrideDefaultFromEnvar("OMS_BATCH_TIME").Duration()
 	omsMaxMsgNumPerBatch = kingpin.Flag("oms-max-msg-num-per-batch", "Max number of messages per OMS batch").Default("1000").OverrideDefaultFromEnvar("OMS_MAX_MSG_NUM_PER_BATCH").Int()
 

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ var (
 	omsWorkspace         = kingpin.Flag("oms-workspace", "OMS workspace ID").OverrideDefaultFromEnvar("OMS_WORKSPACE").Required().String()
 	omsKey               = kingpin.Flag("oms-key", "OMS workspace key").OverrideDefaultFromEnvar("OMS_KEY").Required().String()
 	omsPostTimeout       = kingpin.Flag("oms-post-timeout", "HTTP timeout for posting events to OMS Log Analytics").Default("5s").OverrideDefaultFromEnvar("OMS_POST_TIMEOUT").Duration()
+	omsCustomHeaders     = kingpin.Flag("oms-custom-headers", "HTTP headers to use in post requests to OMS Log Analytics").OverrideDefaultFromEnvar("OMS_CUSTOM_HEADERS").StringMap()
 	omsBatchTime         = kingpin.Flag("oms-batch-time", "Interval to post an OMS batch").Default("5s").OverrideDefaultFromEnvar("OMS_BATCH_TIME").Duration()
 	omsMaxMsgNumPerBatch = kingpin.Flag("oms-max-msg-num-per-batch", "Max number of messages per OMS batch").Default("1000").OverrideDefaultFromEnvar("OMS_MAX_MSG_NUM_PER_BATCH").Int()
 
@@ -169,7 +170,7 @@ func main() {
 
 	firehoseClient := firehose.NewClient(cfClientConfig, firehoseConfig, logger)
 
-	omsClient := client.NewOmsClient(*omsWorkspace, *omsKey, *omsPostTimeout, logger)
+	omsClient := client.NewOmsClient(*omsWorkspace, *omsKey, *omsPostTimeout, *omsCustomHeaders, logger)
 
 	nozzleConfig := &omsnozzle.NozzleConfig{
 		OmsTypePrefix:         omsTypePrefix,

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ var (
 	omsWorkspace         = kingpin.Flag("oms-workspace", "OMS workspace ID").OverrideDefaultFromEnvar("OMS_WORKSPACE").Required().String()
 	omsKey               = kingpin.Flag("oms-key", "OMS workspace key").OverrideDefaultFromEnvar("OMS_KEY").Required().String()
 	omsPostTimeout       = kingpin.Flag("oms-post-timeout", "HTTP timeout for posting events to OMS Log Analytics").Default("5s").OverrideDefaultFromEnvar("OMS_POST_TIMEOUT").Duration()
-	omsCustomHeaders     = kingpin.Flag("oms-custom-headers", "HTTP headers to use in post requests to OMS Log Analytics").OverrideDefaultFromEnvar("OMS_CUSTOM_HEADERS").StringMap()
+	azureResourceId      = kingpin.Flag("azure-resource-id", "Azure Resource Id to set in HTTP header when posting events to Azure Monitor").OverrideDefaultFromEnvar("AZURE_RESOURCE_ID").String()
 	omsBatchTime         = kingpin.Flag("oms-batch-time", "Interval to post an OMS batch").Default("5s").OverrideDefaultFromEnvar("OMS_BATCH_TIME").Duration()
 	omsMaxMsgNumPerBatch = kingpin.Flag("oms-max-msg-num-per-batch", "Max number of messages per OMS batch").Default("1000").OverrideDefaultFromEnvar("OMS_MAX_MSG_NUM_PER_BATCH").Int()
 
@@ -170,7 +170,7 @@ func main() {
 
 	firehoseClient := firehose.NewClient(cfClientConfig, firehoseConfig, logger)
 
-	omsClient := client.NewOmsClient(*omsWorkspace, *omsKey, *omsPostTimeout, *omsCustomHeaders, logger)
+	omsClient := client.NewOmsClient(*omsWorkspace, *omsKey, *omsPostTimeout, *azureResourceId, logger)
 
 	nozzleConfig := &omsnozzle.NozzleConfig{
 		OmsTypePrefix:         omsTypePrefix,

--- a/manifest.yml
+++ b/manifest.yml
@@ -13,8 +13,7 @@ applications:
     OMS_POST_TIMEOUT: 10s
     OMS_BATCH_TIME: 10s
     OMS_MAX_MSG_NUM_PER_BATCH: 1000
-    # OMS_CUSTOM_HEADERS: # Custom headers to be included in the request to OMS (https://docs.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api#request-headers)
-    #   x-ms-AzureResourceId: CHANGE_ME
+    # AZURE_RESOURCE_ID: CHANGE_ME # has to be a real Resource Id (i.e. /subscriptions/<uuid>/resourceGroups/<name>/...)
     FIREHOSE_USER: CHANGE_ME
     FIREHOSE_USER_PASSWORD: CHANGE_ME
     # API_ADDR: https://api.<CF_SYSTEM_DOMAIN>  # CF API Address. If current environment is to be monitored, leave it empty/commented and nozzle will fetch its addresses automatically

--- a/manifest.yml
+++ b/manifest.yml
@@ -13,7 +13,7 @@ applications:
     OMS_POST_TIMEOUT: 10s
     OMS_BATCH_TIME: 10s
     OMS_MAX_MSG_NUM_PER_BATCH: 1000
-    # AZURE_RESOURCE_ID: CHANGE_ME # has to be a real Resource Id (i.e. /subscriptions/<uuid>/resourceGroups/<name>/...)
+    # AZURE_RESOURCE_ID: CHANGE_ME # i.e. /subscriptions/<uuid>/resourceGroups/<name>/...
     FIREHOSE_USER: CHANGE_ME
     FIREHOSE_USER_PASSWORD: CHANGE_ME
     # API_ADDR: https://api.<CF_SYSTEM_DOMAIN>  # CF API Address. If current environment is to be monitored, leave it empty/commented and nozzle will fetch its addresses automatically

--- a/manifest.yml
+++ b/manifest.yml
@@ -13,6 +13,8 @@ applications:
     OMS_POST_TIMEOUT: 10s
     OMS_BATCH_TIME: 10s
     OMS_MAX_MSG_NUM_PER_BATCH: 1000
+    # OMS_CUSTOM_HEADERS: # Custom headers to be included in the request to OMS (https://docs.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api#request-headers)
+    #   x-ms-AzureResourceId: CHANGE_ME
     FIREHOSE_USER: CHANGE_ME
     FIREHOSE_USER_PASSWORD: CHANGE_ME
     # API_ADDR: https://api.<CF_SYSTEM_DOMAIN>  # CF API Address. If current environment is to be monitored, leave it empty/commented and nozzle will fetch its addresses automatically

--- a/pcf-tile/tile.yml
+++ b/pcf-tile/tile.yml
@@ -100,6 +100,11 @@ forms:
      constraints:
        min: 1
        max: 10000
+   - name: azure_resource_id
+     type: string
+     optional: true
+     label: Azure Resource Id
+     description: e.g. /subscriptions/<uuid>/resourceGroups/<name>/... . If set, the Resource Id will be attached to all the logs sent to Azure Monitor via this nozzle.
    - name: firehose_user
      type: string
      label: Firehose Username

--- a/pcf-tile/tile.yml
+++ b/pcf-tile/tile.yml
@@ -104,7 +104,7 @@ forms:
      type: string
      optional: true
      label: Azure Resource Id
-     description: e.g. /subscriptions/<uuid>/resourceGroups/<name>/... . If set, the Resource Id will be attached to all the logs sent to Azure Monitor via this nozzle.
+     description: e.g. /subscriptions/<uuid>/resourceGroups/<name>/... . Set a Resource Id to be included when posting events
    - name: firehose_user
      type: string
      label: Firehose Username


### PR DESCRIPTION
We've updated the nozzle to accept an `AZURE_RESOURCE_ID` env variable that will enable and populate the the `x-ms-AzureResourceId` header in the [POST request](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api#request-headers) to Azure Monitor. The variable can be set either via the tile config or via the app manifest, depending on the operators deployment.

This change will allow platform operators to attach Resource Ids to logs from individual foundations, spaces, etc., allowing for cross-context searching in Azure Monitor.