### PR TITLE
Fix staticcheck errors

### DIFF
--- a/caching/caching.go
+++ b/caching/caching.go
@@ -89,7 +89,6 @@ func (c *Caching) addAppinfoRecord(app cfclient.App) {
 		lager.Data{"guid": app.Guid},
 		lager.Data{"info": appInfo},
 	)
-	return
 }
 
 func (c *Caching) Initialize() {
@@ -102,11 +101,8 @@ func (c *Caching) Initialize() {
 	go func() {
 		time.Sleep(time.Duration(float64(c.cachingInterval) * rand.Float64()))
 		ticker := time.NewTicker(c.cachingInterval)
-		for {
-			select {
-			case <-ticker.C:
-				c.refreshCache()
-			}
+		for range ticker.C {
+			c.refreshCache()
 		}
 	}()
 }
@@ -165,7 +161,6 @@ func (c *Caching) refreshCache() {
 	c.appInfosByGuid = newAppInfo
 	c.appInfoLock.Unlock()
 	c.logger.Debug("Refreshed")
-	return
 }
 
 func (c *Caching) GetAppInfo(appGuid string) AppInfo {

--- a/mocks/caching.go
+++ b/mocks/caching.go
@@ -24,5 +24,4 @@ func (c *MockCaching) GetEnvironmentName() string {
 }
 
 func (c *MockCaching) Initialize() {
-	return
 }

--- a/omsnozzle/oms_nozzle.go
+++ b/omsnozzle/oms_nozzle.go
@@ -29,7 +29,6 @@ type ProcessedMessage struct {
 type OmsNozzle struct {
 	logger              lager.Logger
 	maxCCGoroutines     int
-	errChan             <-chan error
 	msgChan             chan *events.Envelope
 	processedMessages   chan ProcessedMessage
 	signalChan          chan os.Signal
@@ -357,8 +356,7 @@ func (o *OmsNozzle) logSlowConsumerAlert() {
 		ValueMetric: valueMetric,
 	}
 
-	var omsMsg OMSMessage
-	omsMsg = messages.NewValueMetric(envelope, o.cachingClient)
+	omsMsg := messages.NewValueMetric(envelope, o.cachingClient)
 	currentEvents := make(map[string][]interface{})
 	currentEvents[eventType.String()] = append(currentEvents[eventType.String()], omsMsg)
 


### PR DESCRIPTION
# Description

Fixes some of the errors generated by `staticcheck ./...`

```
caching/caching.go:92:2: redundant return statement (S1023)
caching/caching.go:105:3: should use for range instead of for { select {} } (S1000)
caching/caching.go:168:2: redundant return statement (S1023)
mocks/caching.go:27:2: redundant return statement (S1023)
omsnozzle/oms_nozzle.go:31:2: field errChan is unused (U1000)
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

