### PR TITLE
Prefer cflinuxfs4

### DIFF
--- a/pcf-tile/tile.yml
+++ b/pcf-tile/tile.yml
@@ -26,6 +26,17 @@ packages:
   type: app
 #  label: My fabulous appplication      # Package name for use in human-readable labels in OpsManager
   pre_deploy: |
+    # redefine get_stack to prefer cflinuxfs4
+    function get_stack() {
+      stack="$($CF buildpacks | grep 'go_buildpack' | grep -o 'cflinuxfs[34]' | sort -uVr | head -n1)"
+      if [ -z "$stack" ]; then
+          echo >&2 "Using default stack"
+      else
+          echo >&2 "Using $stack stack"
+          echo "-s $stack"
+      fi
+    }
+
     cf delete-org -f azure-log-analytics-nozzle-org
   manifest:
     path: resources/azure-log-analytics-nozzle.zip


### PR DESCRIPTION
# Description

- The tile-generator will currently use cflinuxfs3 if it exists even if cflinuxfs4 is the default stack: https://github.com/cf-platform-eng/tile-generator/issues/325
- Redefine the `get_stack` function to prefer cflinuxfs4 if available.
- Only use cflinuxfs4 if the `go_buildpack` is available. Some environments will have the cflinuxfs4 stack but no `go_buildpack` for cflinuxfs4.
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [X] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
