### PR TITLE
Pin to cf-cli-release v1.45.0

### DIFF
--- a/pcf-tile/tile.yml
+++ b/pcf-tile/tile.yml
@@ -49,6 +49,12 @@ packages:
       GOPACKAGENAME: github.com/vmware-tanzu/nozzle-for-microsoft-azure-log-analytics
   health_check: none
 
+release_overides:
+  cf-cli-release:
+    name: cf-cli-release
+    type: bosh-release
+    path: https://bosh.io/d/github.com/bosh-packages/cf-cli-release?v=1.45.0
+
 # Include stemcell criteria if you don't want to accept the default.
 # Since this stemcell is only used to run pre and post errands, we
 # strongly recommend you leave this alone so that your tile always


### PR DESCRIPTION
# Description

- Default build behaviour is to use the latest cf CLI version available on bosh.io
- Currently v1.46.0 is the latest downloaded cf CLI version. However it is an odd release and not tagged on GitHub.
- Pin to v1.45.0 for now.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [ ] Integration tests
- [X] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
